### PR TITLE
Make error handling environment agnostic

### DIFF
--- a/svg-path-to-polygons.js
+++ b/svg-path-to-polygons.js
@@ -44,8 +44,7 @@ function svgPathToPolygons(svgPathString, opts={}) {
 			break;
 
 			default:
-				console.error('Our deepest apologies, but '+cmd.command+' commands ('+cmd.code+') are not yet supported.');
-				process.exit(2);
+				throw new Error('Our deepest apologies, but '+cmd.command+' commands ('+cmd.code+') are not yet supported.');
 		}
 		prev = cmd;
 	});


### PR DESCRIPTION
The only thing preventing this library to be used in a browser environment seems to be the `process.exit` used to throw an error when a SVG command is not recognised, because the `process` API is not available in the browser environment.

Instead of terminating the process, throwing an error allows the user to choose its own method of handling the error, and avoid using the `process` API.